### PR TITLE
Add simulation speed control

### DIFF
--- a/Psych/JS/sim.js
+++ b/Psych/JS/sim.js
@@ -17,6 +17,16 @@ const engine = Engine.create();
 const world = engine.world;
 engine.gravity.y = 0;
 
+// Global simulation speed multiplier (1 = normal speed)
+let simSpeed = 1;
+engine.timing.timeScale = simSpeed;
+
+// Expose setter for convenience in console
+window.setSimSpeed = speed => {
+  simSpeed = speed;
+  engine.timing.timeScale = simSpeed;
+};
+
 const width = window.innerWidth;
 const height = window.innerHeight;
 


### PR DESCRIPTION
## Summary
- add global `simSpeed` variable and `setSimSpeed` function in `sim.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68520ac093a48330b71ba3933c9ad1ce