### PR TITLE
Add UI control for simulation speed

### DIFF
--- a/Psych/JS/sim.js
+++ b/Psych/JS/sim.js
@@ -17,6 +17,20 @@ const engine = Engine.create();
 const world = engine.world;
 engine.gravity.y = 0;
 
+// Global simulation speed multiplier (1 = normal speed)
+let simSpeed = 1;
+engine.timing.timeScale = simSpeed;
+
+// Expose setter for convenience in console and UI
+window.setSimSpeed = speed => {
+  simSpeed = speed;
+  engine.timing.timeScale = simSpeed;
+  const input = document.getElementById('speedControl');
+  const display = document.getElementById('speedDisplay');
+  if (input) input.value = simSpeed;
+  if (display) display.textContent = simSpeed.toFixed(1);
+};
+
 const width = window.innerWidth;
 const height = window.innerHeight;
 
@@ -203,4 +217,17 @@ function processInteractions() {
 }
 
 loadConfig().then(createParticles);
+
+// Hook up speed slider after DOM loads
+window.addEventListener('DOMContentLoaded', () => {
+  const ctrl = document.getElementById('speedControl');
+  const display = document.getElementById('speedDisplay');
+  if (!ctrl) return;
+  ctrl.value = simSpeed;
+  if (display) display.textContent = simSpeed.toFixed(1);
+  ctrl.addEventListener('input', e => {
+    const val = parseFloat(e.target.value);
+    setSimSpeed(val);
+  });
+});
 

--- a/Psych/index.html
+++ b/Psych/index.html
@@ -8,6 +8,13 @@
   </style>
 </head>
 <body>
+  <div id="controlPanel" style="position:fixed;top:10px;left:10px;color:white;font-family:sans-serif">
+    <label>
+      Speed:
+      <input id="speedControl" type="range" min="0.1" max="3" step="0.1" value="1" />
+      <span id="speedDisplay">1</span>x
+    </label>
+  </div>
   <script src="https://cdn.jsdelivr.net/npm/matter-js"></script>
   <script src="JS/sim.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a speed slider UI so sim speed can be edited live
- sync `setSimSpeed` with the slider and display

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68520ac093a48330b71ba3933c9ad1ce