### PR TITLE
Add tag-level attraction radius

### DIFF
--- a/Psych/JS/sim.js
+++ b/Psych/JS/sim.js
@@ -74,6 +74,7 @@ class Particle {
     this.knockRes = opts.knockRes;
     this.mouseAttract = opts.mouseAttract;
     this.attractCoef = opts.attractCoef;
+    this.attractRadius = opts.attractRadius || blankTagMap();
     this.mouseAttractradius = opts.mouseAttractRadius;
     this.suscept = opts.suscept;
     this.state = 'idle';
@@ -127,7 +128,8 @@ class Particle {
         Matter.Body.applyForce(this.body, this.body.position, Vector.mult(norm, kb));
       }
       const att = val * (this.attractCoef[tag] || 0);
-      if (att) {
+      const radius = this.attractRadius[tag] || 0;
+      if (att && dist > radius) {
         const norm = Vector.normalise(toOther);
         Matter.Body.applyForce(this.body, this.body.position, Vector.mult(norm, att));
       }
@@ -155,6 +157,7 @@ function createParticles() {
         knockRes: randomTagMap(-0.01,0.01),
         attractCoef: randomTagMap(-0.0005, 0.0005),
         suscept: randomTagMap(-1, 1),
+        attractRadius: randomTagMap(20, 100),
         mouseAttract: Math.random(),
       };
       const p = new Particle(

--- a/Psych/config/particles.json
+++ b/Psych/config/particles.json
@@ -8,6 +8,7 @@
       "frictionAir": 0.3,
       "mouseAttract": {},
       "mouseAttractRadius": 100,
+      "attractRadius": {},
       "tags": {},
       "knockRes": {},
       "attractCoef": {},

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ tag maps to a single hexadecimal digit in the `#RRGGBB` code, so different tag
 combinations produce different colors.
 
 Particle properties like radius and restitution can be tweaked in
-`DEFAULT_PARTICLE_OPTIONS` inside `Psych/JS/sim.js`.
+`DEFAULT_PARTICLE_OPTIONS` inside `Psych/JS/sim.js`. Attraction radii are now
+stored per tag in an `attractRadius` map. Values for this map are randomly
+generated for each particle, but can be overridden per class in
+`Psych/config/particles.json`. Attraction forces only apply when two particles
+are farther apart than the corresponding tag radius.
 
 Open `Psych/index.html` in a browser to see the simulation.


### PR DESCRIPTION
## Summary
- store attract radius per tag in each particle
- randomize `attractRadius` for new particles
- update particle config format
- document per-tag `attractRadius`

## Testing
- `node --check Psych/JS/sim.js`
- `jq . Psych/config/particles.json`

------
https://chatgpt.com/codex/tasks/task_e_685228f142f883309d56a2f0cdde502e