### PR TITLE
Add custom particle input form

### DIFF
--- a/Psych/JS/sim.js
+++ b/Psych/JS/sim.js
@@ -65,6 +65,37 @@ function randomTagMap(min, max) {
   }, {});
 }
 
+// Return a copy of tags for simple formulas
+function identityTagMap(tags) {
+  return TAG_NAMES.reduce((o, t) => {
+    o[t] = tags[t] || 0;
+    return o;
+  }, {});
+}
+
+function addParticleWithTags(tags) {
+  if (!config) return;
+  const cls = config.classes && config.classes[0] ? config.classes[0] : {};
+  const opts = {
+    ...cls,
+    tags: identityTagMap(tags),
+    knockRes: identityTagMap(tags),
+    attractCoef: identityTagMap(tags),
+    suscept: randomTagMap(-1, 1),
+    outerAttractRadius: randomTagMap(400, 600),
+    innerAttractRadius: randomTagMap(20, 50),
+    mouseAttract: Math.random(),
+  };
+  const p = new Particle(
+    Math.random() * width,
+    Math.random() * height,
+    opts
+  );
+  particles.push(p);
+  bodyToParticle.set(p.body, p);
+  World.add(world, p.body);
+}
+
 class Particle {
   constructor(x, y, options = {}) {
     const opts = options;
@@ -244,5 +275,25 @@ window.addEventListener('DOMContentLoaded', () => {
     const val = parseFloat(e.target.value);
     setSimSpeed(val);
   });
+
+  const btn = document.getElementById('createParticleBtn');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      const vals = [
+        document.getElementById('ieInput'),
+        document.getElementById('snInput'),
+        document.getElementById('tfInput'),
+        document.getElementById('jpInput'),
+        document.getElementById('atInput'),
+        document.getElementById('extraInput'),
+      ].map(inp => parseFloat(inp.value) || 0);
+      const toTagVal = p => Math.max(-1, Math.min(1, (p - 50) / 50));
+      const tagMap = TAG_NAMES.reduce((o, t, i) => {
+        o[t] = toTagVal(vals[i] || 0);
+        return o;
+      }, {});
+      addParticleWithTags(tagMap);
+    });
+  }
 });
 

--- a/Psych/index.html
+++ b/Psych/index.html
@@ -14,6 +14,17 @@
       <input id="speedControl" type="range" min="0.1" max="3" step="0.1" value="1" />
       <span id="speedDisplay">1</span>x
     </label>
+    <div id="particleForm" style="margin-top:10px">
+      <div>
+        <label>I/E <input id="ieInput" type="number" min="1" max="100" value="50" style="width:60px"/></label>
+        <label>S/N <input id="snInput" type="number" min="1" max="100" value="50" style="width:60px"/></label>
+        <label>T/F <input id="tfInput" type="number" min="1" max="100" value="50" style="width:60px"/></label>
+        <label>J/P <input id="jpInput" type="number" min="1" max="100" value="50" style="width:60px"/></label>
+        <label>A/T <input id="atInput" type="number" min="1" max="100" value="50" style="width:60px"/></label>
+        <label>Extra <input id="extraInput" type="number" min="1" max="100" value="50" style="width:60px"/></label>
+      </div>
+      <button id="createParticleBtn" style="margin-top:5px">Create Particle</button>
+    </div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/matter-js"></script>
   <script src="JS/sim.js"></script>


### PR DESCRIPTION
## Summary
- add form with six percentage inputs and a creation button to the page
- include utility to create particles from provided percentages
- hook button into the simulation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685256ccc7788330a293066b79182953